### PR TITLE
fix(blog): readable code blocks in light mode

### DIFF
--- a/src/lib/design/lib/BlogBody.svelte
+++ b/src/lib/design/lib/BlogBody.svelte
@@ -81,7 +81,7 @@
   .body :global(code) {
     font-family: var(--font-mono);
     font-size: 0.88em;
-    background: var(--ink-900);
+    background: var(--bg-raised);
     padding: 0.15em 0.4em;
     border-radius: 3px;
     border: 1px solid var(--hairline);
@@ -90,7 +90,7 @@
 
   /* Code blocks */
   .body :global(pre) {
-    background: var(--ink-900);
+    background: var(--bg-raised);
     border: 1px solid var(--hairline);
     border-radius: 8px;
     padding: 20px 22px;


### PR DESCRIPTION
## Summary

- Code blocks (\`pre\`) and inline \`code\` were using \`--ink-900\` for background (a fixed dark charcoal) while \`--fg\` is theme-aware. In light mode this rendered dark-on-dark and was unreadable.
- Switched both to \`--bg-raised\`, which is white in light mode and charcoal in dark mode — same approach as the global \`app.css\` \`pre\`/\`code\` rules.

## Test plan

- [x] \`pnpm build\` passes
- [ ] Toggle light/dark on a blog post with code blocks and verify both modes are legible