### PR TITLE
fix(hero): point "See my work" CTA to /#work

### DIFF
--- a/src/lib/design/lib/Hero.svelte
+++ b/src/lib/design/lib/Hero.svelte
@@ -3,7 +3,7 @@
   export let kicker = '▲ ASHUTOSH TRIPATHI · SOFTWARE ENGINEER';
   export let primaryHref = '/blog';
   export let primaryLabel = 'Read my writing';
-  export let secondaryHref = '/work';
+  export let secondaryHref = '/#work';
   export let secondaryLabel = 'See my work →';
 </script>
 


### PR DESCRIPTION
## Summary
- Hero's secondary CTA defaulted to `/work`, which is not a route — work lives as a section anchor (`#work`) on the homepage. Clicking "See my work →" from the landing hero hit a 404.

## Test plan
- [ ] Load the homepage, click "See my work →", confirm it scrolls to the projects section instead of 404