### PR TITLE
feat(work): restore /work page as a proper route

### DIFF
--- a/src/lib/data/site.ts
+++ b/src/lib/data/site.ts
@@ -19,7 +19,7 @@ export const siteConfig = {
 
 export const navLinks = [
 	{ href: '/blog', text: 'Writing' },
-	{ href: '/#work', text: 'Work' },
+	{ href: '/work', text: 'Work' },
 	{ href: '/#contact', text: 'Contact' }
 ];
 
@@ -30,7 +30,7 @@ export const hero = {
 		'Developer tools and AI-native systems. I design the infrastructure that lets agents — human and automated — operate without friction. A decade of product engineering.',
 	ctas: [
 		{ label: 'Read my writing', href: '/blog' },
-		{ label: 'See my work', href: '/#work' }
+		{ label: 'See my work', href: '/work' }
 	]
 };
 
@@ -69,20 +69,54 @@ export const craftAreas = [
 	}
 ];
 
-export const projects = [
+export type ProjectStatus = 'live' | 'sunset' | 'delivered';
+
+export type Project = {
+	name: string;
+	description: string;
+	role: string;
+	stack: string[];
+	href: string | null;
+	status: ProjectStatus;
+	featured: boolean;
+};
+
+export const projects: Project[] = [
 	{
 		name: 'Smriti',
 		description: 'Shared memory for AI-powered engineering teams. Captures and indexes Claude Code, Cursor, and Codex sessions locally, then shares team knowledge through git. No cloud required.',
 		role: 'Concept, CLI design, search architecture, development',
 		stack: ['Bun', 'TypeScript', 'SQLite', 'BM25', 'node-llama-cpp', 'Ollama'],
-		href: 'https://github.com/zero8dotdev/smriti'
+		href: 'https://github.com/zero8dotdev/smriti',
+		status: 'live',
+		featured: true
 	},
 	{
 		name: 'Avkash',
 		description: "India's open-source HR platform: leave management, team policies, and Slack integration for modern workplaces. Self-hostable, with Razorpay billing and row-level security built in.",
 		role: 'Product, design, architecture, development',
 		stack: ['Next.js 15', 'TypeScript', 'Supabase', 'Slack API', 'Razorpay', 'Tailwind CSS'],
-		href: 'https://github.com/zero8dotdev/avkash'
+		href: 'https://github.com/zero8dotdev/avkash',
+		status: 'live',
+		featured: true
+	},
+	{
+		name: 'Godspeed Web',
+		description: 'A visual platform to create, manage, and deploy Godspeed Framework projects — taking a low-code framework to no-code. Built to remove the CLI entirely for teams who want to ship without the setup.',
+		role: 'Product, design, architecture, development',
+		stack: ['TypeScript', 'JavaScript'],
+		href: null,
+		status: 'sunset',
+		featured: false
+	},
+	{
+		name: 'Workflow Management',
+		description: 'A workflow automation platform for Veolia Japan — teams could build, configure, and publish operational workflows without touching code. The frontend was the hard part: a visual drag-and-drop builder, dynamic multi-step forms rendered from a workflow schema, complex state management across branching flows, and role-based views that controlled what each team member could see and act on at every stage.',
+		role: 'Frontend architecture, development',
+		stack: ['React', 'TypeScript'],
+		href: null,
+		status: 'delivered',
+		featured: false
 	}
 ];
 

--- a/src/lib/design/lib/Hero.svelte
+++ b/src/lib/design/lib/Hero.svelte
@@ -3,7 +3,7 @@
   export let kicker = '▲ ASHUTOSH TRIPATHI · SOFTWARE ENGINEER';
   export let primaryHref = '/blog';
   export let primaryLabel = 'Read my writing';
-  export let secondaryHref = '/#work';
+  export let secondaryHref = '/work';
   export let secondaryLabel = 'See my work →';
 </script>
 

--- a/src/lib/design/lib/TopNav.svelte
+++ b/src/lib/design/lib/TopNav.svelte
@@ -3,7 +3,7 @@
   /** @type {Array<{href: string, label: string}>} */
   export let links = [
     { href: '/blog', label: 'writing' },
-    { href: '/#work', label: 'work' },
+    { href: '/work', label: 'work' },
   ];
   export let active = 'writing';
   export let ctaHref = 'mailto:hello@zero8.dev';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,12 +5,14 @@
 
 	let { data }: { data: PageData } = $props();
 
-	const projectItems = projects.map((p) => ({
-		status: 'live' as const,
-		name: p.name,
-		tags: p.stack.join(' · '),
-		desc: p.description
-	}));
+	const projectItems = projects
+		.filter((p) => p.featured)
+		.map((p) => ({
+			status: 'live' as const,
+			name: p.name,
+			tags: p.stack.join(' · '),
+			desc: p.description
+		}));
 
 	const postItems = data.posts.map((p) => ({
 		date: p.date,

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -8,6 +8,7 @@ export const GET: RequestHandler = () => {
 
 	const staticPages = [
 		{ loc: `${siteConfig.url}/`, priority: '1.0', changefreq: 'weekly', lastmod: today },
+		{ loc: `${siteConfig.url}/work`, priority: '0.9', changefreq: 'monthly', lastmod: today },
 		{ loc: `${siteConfig.url}/blog`, priority: '0.8', changefreq: 'weekly', lastmod: today }
 	];
 

--- a/src/routes/work/+page.svelte
+++ b/src/routes/work/+page.svelte
@@ -1,0 +1,198 @@
+<script lang="ts">
+	import { TopNav, Footer, Kicker } from '$lib/design/lib';
+	import { projects, siteConfig } from '$lib/data/site';
+
+	const current = projects.filter((p) => p.featured);
+	const past = projects.filter((p) => !p.featured);
+</script>
+
+<svelte:head>
+	<title>work · zero8.dev</title>
+	<meta name="description" content="Selected projects by Ashutosh Tripathi — active work and past projects in developer tools, AI infrastructure, and product engineering." />
+	<link rel="canonical" href="{siteConfig.url}/work" />
+	<meta property="og:title" content="work · zero8.dev" />
+	<meta property="og:description" content="Selected projects by Ashutosh Tripathi — active work and past projects in developer tools, AI infrastructure, and product engineering." />
+	<meta property="og:url" content="{siteConfig.url}/work" />
+	<meta property="og:type" content="website" />
+	<meta property="og:image" content={siteConfig.ogImage.url} />
+	<meta property="og:image:width" content="{siteConfig.ogImage.width}" />
+	<meta property="og:image:height" content="{siteConfig.ogImage.height}" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content="work · zero8.dev" />
+	<meta name="twitter:image" content={siteConfig.ogImage.url} />
+</svelte:head>
+
+<TopNav active="work" />
+<main id="main" class="column">
+	<Kicker accent>ASHUTOSH TRIPATHI · SELECTED WORK</Kicker>
+	<h1>work</h1>
+	<p class="lede">Active projects and past work. Some are still growing, some shipped and moved on.</p>
+
+	<div class="projects">
+		{#each current as project}
+			<article class="project">
+				<div class="meta">
+					<span class="status-pill live">● live</span>
+					<span class="role">{project.role}</span>
+				</div>
+				<h2 class="name">{project.name}</h2>
+				<p class="desc">{project.description}</p>
+				<div class="footer-row">
+					<span class="stack">{project.stack.join(' · ')}</span>
+					{#if project.href}
+						<a href={project.href} class="link" target="_blank" rel="noopener noreferrer">GitHub →</a>
+					{/if}
+				</div>
+			</article>
+		{/each}
+	</div>
+
+	<h2 class="section-label">Past work</h2>
+
+	<div class="projects">
+		{#each past as project}
+			<article class="project">
+				<div class="meta">
+					{#if project.status === 'sunset'}
+						<span class="status-pill sunset">○ sunset</span>
+					{:else}
+						<span class="status-pill delivered">○ delivered</span>
+					{/if}
+					<span class="role">{project.role}</span>
+				</div>
+				<h2 class="name">{project.name}</h2>
+				<p class="desc">{project.description}</p>
+				<div class="footer-row">
+					<span class="stack">{project.stack.join(' · ')}</span>
+					{#if project.href}
+						<a href={project.href} class="link" target="_blank" rel="noopener noreferrer">GitHub →</a>
+					{/if}
+				</div>
+			</article>
+		{/each}
+	</div>
+</main>
+<Footer />
+
+<style>
+	.column {
+		width: 100%;
+		max-width: var(--wide-width);
+		margin: 0 auto;
+		padding: 80px 32px 64px;
+	}
+
+	h1 {
+		font-family: var(--font-sans);
+		font-size: clamp(40px, 6vw, 64px);
+		font-weight: 700;
+		letter-spacing: -0.03em;
+		line-height: var(--lh-tight);
+		color: var(--fg);
+		margin: var(--s-5) 0 var(--s-5);
+		text-wrap: balance;
+	}
+
+	.lede {
+		font-size: 19px;
+		color: var(--fg-muted);
+		line-height: var(--lh-base);
+		margin: 0 0 var(--s-8);
+	}
+
+	.section-label {
+		font-family: var(--font-sans);
+		font-size: 22px;
+		font-weight: 600;
+		letter-spacing: -0.02em;
+		color: var(--fg);
+		margin: var(--s-9) 0 var(--s-5);
+	}
+
+	.projects {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.project {
+		padding: var(--s-7) 0;
+		border-top: 1px solid var(--hairline);
+	}
+
+	.project:last-child {
+		border-bottom: 1px solid var(--hairline);
+	}
+
+	.meta {
+		display: flex;
+		align-items: center;
+		gap: var(--s-4);
+		margin-bottom: var(--s-3);
+		flex-wrap: wrap;
+	}
+
+	.status-pill {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		letter-spacing: 0.05em;
+	}
+
+	.status-pill.live { color: var(--peach-500); }
+	.status-pill.sunset { color: var(--fg-faint); }
+	.status-pill.delivered { color: var(--fg-faint); }
+
+	.role {
+		font-family: var(--font-mono);
+		font-size: 12px;
+		color: var(--fg-faint);
+	}
+
+	.name {
+		font-family: var(--font-sans);
+		font-size: 28px;
+		font-weight: 700;
+		letter-spacing: -0.025em;
+		color: var(--fg);
+		margin: 0 0 var(--s-4);
+		line-height: var(--lh-tight);
+	}
+
+	.desc {
+		font-size: 16px;
+		color: var(--fg-muted);
+		line-height: var(--lh-base);
+		margin: 0 0 var(--s-5);
+	}
+
+	.footer-row {
+		display: flex;
+		align-items: baseline;
+		gap: var(--s-5);
+		flex-wrap: wrap;
+	}
+
+	.stack {
+		font-family: var(--font-mono);
+		font-size: 12px;
+		color: var(--fg-faint);
+		letter-spacing: -0.01em;
+	}
+
+	.link {
+		font-family: var(--font-mono);
+		font-size: 12px;
+		color: var(--fg-muted);
+		text-decoration: none;
+		transition: color var(--dur-fast) ease;
+	}
+
+	.link:hover {
+		color: var(--peach-500);
+	}
+
+	@media (max-width: 640px) {
+		.column { padding: var(--s-7) var(--s-5) var(--s-8); }
+		h1 { font-size: 32px; }
+		.name { font-size: 22px; }
+	}
+</style>


### PR DESCRIPTION
## Summary
- Restores the parked `/work` route from the homepage-redesign WIP (commit `fdfea82`), adapted to the current `Kicker` API and design tokens.
- Lists **featured projects** (live) and **past work** (sunset/delivered) — each with role, stack, and GitHub link.
- Adds two past projects: **Godspeed Web** (sunset) and **Workflow Management at Veolia Japan** (delivered).
- Homepage *Selected work* now filters to `featured: true` only, so the homepage stays focused on current work.
- Hero CTA, `TopNav`, `navLinks`, and `hero.ctas` all point at `/work` instead of the `/#work` anchor.
- Sitemap includes `/work`.

## Test plan
- [ ] `/work` renders with two live projects (Smriti, Avkash) and two past projects (Godspeed Web sunset, Workflow Management delivered).
- [ ] Homepage hero "See my work →" navigates to `/work` (not 404, not anchor).
- [ ] Homepage *Selected work* shows only Smriti + Avkash.
- [ ] TopNav "work" link goes to `/work`.
- [ ] Mobile layout collapses cleanly (320 / 375 widths).
- [ ] `/sitemap.xml` includes `/work`.